### PR TITLE
Fix for Py 3.7

### DIFF
--- a/tastypie_mongoengine/resources.py
+++ b/tastypie_mongoengine/resources.py
@@ -224,9 +224,9 @@ class MongoEngineModelDeclarativeMetaclass(resources.ModelDeclarativeMetaclass):
                     del(new_class.base_fields[field_name])
             if field_name in new_class.declared_fields:
                 continue
-            if len(include_fields) and field_name not in include_fields:
+            if include_fields is not None and field_name not in include_fields:
                 del(new_class.base_fields[field_name])
-            if len(excludes) and field_name in excludes:
+            if excludes is not None and field_name in excludes:
                 del(new_class.base_fields[field_name])
 
         # Add in the new fields


### PR DESCRIPTION
  File "/usr/local/lib/python3.7/site-packages/tastypie_mongoengine/resources.py", line 227, in __new__
    if len(include_fields) and field_name not in include_fields:
TypeError: object of type 'NoneType' has no len()